### PR TITLE
Add note about local file

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ Tools to help build and install Jupyter Python packages
 
 ## Usage
 
-Below is an example `setup.py` that uses jupyter-packaging:
+Below is an example `setup.py` that uses jupyter-packaging.  The 
+contents of `jupyter_packaging.py` are copied locally to `setupbase.py`
+so they are available to run the `setup.py` script itself.
 
 ```py
 from setuptools import setup
-from jupyter_packaging import create_cmdclass, install_npm
+from setupbase import create_cmdclass, install_npm
 
 
 cmdclass = create_cmdclass(['js'])


### PR DESCRIPTION
@gnestor, it looks like the bootstrapping does not work.  The problem is that `setuptools`' `easy_install` is used to fetch the `setup_requires` modules, and does a poor job of it.  In our case, it installed `./.eggs/jupyter_packaging-0.1.0-py3.5.egg`, but the file itself does not work for importing. 

The example given by [setuphelpers](https://github.com/ccpgames/setuphelpers#a-note-on-setup_requires) doesn't work for that library either: `distutils.errors.DistutilsError: Could not find suitable distribution for Requirement.parse('setuphelpers')`.

 If I `pip install jupyter-packaging`, it works directly, but we don't want to force that explicit step on all developers.

