### PR TITLE
Fix `is_stale` for file paths

### DIFF
--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -128,7 +128,7 @@ def is_stale(target, source):
     """
     if not os.path.exists(target):
         return True
-    target_mtime = recursive_mtime(target)
+    target_mtime = recursive_mtime(target) or 0
     return compare_recursive_mtime(source, cutoff=target_mtime)
 
 
@@ -179,6 +179,13 @@ def compare_recursive_mtime(path, cutoff, newest=True):
     E.g. if newest=True, and a file in path is newer than the cutoff, it will
     return True.
     """
+    if os.path.isfile(path):
+        mt = mtime(path)
+        if newest:
+            if mt > cutoff:
+                return True
+        elif mt < cutoff:
+            return True
     for dirname, _, filenames in os.walk(path, topdown=False):
         for filename in filenames:
             mt = mtime(pjoin(dirname, filename))
@@ -192,6 +199,8 @@ def compare_recursive_mtime(path, cutoff, newest=True):
 
 def recursive_mtime(path, newest=True):
     """Gets the newest/oldest mtime for all files in a directory."""
+    if os.path.isfile(path):
+        return mtime(path)
     current_extreme = None
     for dirname, _, filenames in os.walk(path, topdown=False):
         for filename in filenames:

--- a/tests/test_is_stale.py
+++ b/tests/test_is_stale.py
@@ -38,3 +38,33 @@ def test_only_newest_files_determine_stale(source_dir, destination_dir):
     source_dir.join('file1.txt').setmtime(30000)
     destination_dir.join('file1.rtf').setmtime(40000)
     assert is_stale(str(destination_dir), str(source_dir)) is False
+
+
+def test_unstale_on_equal(source_dir):
+    assert is_stale(str(source_dir), str(source_dir)) is False
+
+
+
+def test_file_vs_dir(source_dir, destination_dir):
+    assert is_stale(str(destination_dir.join('file1.rtf')), str(source_dir)) is False
+    source_dir.join('file2.txt').setmtime(30000)
+    assert is_stale(str(destination_dir.join('file1.rtf')), str(source_dir)) is True
+
+
+def test_dir_vs_file(source_dir, destination_dir):
+    assert is_stale(str(destination_dir), str(source_dir.join('file1.txt'))) is False
+    source_dir.join('file1.txt').setmtime(30000)
+    assert is_stale(str(destination_dir), str(source_dir.join('file1.txt'))) is True
+
+
+def test_file_vs_file(source_dir, destination_dir):
+    assert is_stale(str(destination_dir.join('file1.rtf')), str(source_dir.join('file1.txt'))) is False
+    source_dir.join('file1.txt').setmtime(30000)
+    assert is_stale(str(destination_dir.join('file1.rtf')), str(source_dir.join('file1.txt'))) is True
+
+
+def test_empty_dir(source_dir, tmpdir):
+    empty_dir = tmpdir.mkdir('empty')
+    assert is_stale(str(empty_dir), str(source_dir)) is True
+    assert is_stale(str(source_dir), str(empty_dir)) is False
+    assert is_stale(str(empty_dir), str(empty_dir)) is False


### PR DESCRIPTION
Previously `recursive_mtimes` assumed path was always a directory. Now it supports files as well.

Also fixes a bug when the target directory was empty.