### PR TITLE
Add basic tests + fixes for find_packages

### DIFF
--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -78,7 +78,8 @@ def find_packages(top):
     packages = []
     for d, _, _ in os.walk(top):
         if os.path.exists(pjoin(d, '__init__.py')):
-            packages.append(d.replace(os.path.sep, '.'))
+            packages.append(os.path.relpath(d, top).replace(os.path.sep, '.'))
+    return packages
 
 
 def update_package_data(distribution):

--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -76,9 +76,12 @@ def find_packages(top):
     Find all of the packages.
     """
     packages = []
-    for d, _, _ in os.walk(top):
+    for d, dirs, _ in os.walk(top, followlinks=True):
         if os.path.exists(pjoin(d, '__init__.py')):
             packages.append(os.path.relpath(d, top).replace(os.path.sep, '.'))
+        elif d != top:
+            # Do not look for packages in subfolders if current is not a package
+            dirs[:] = []
     return packages
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,16 +5,20 @@
 # Distributed under the terms of the Modified BSD License.
 
 from __future__ import print_function
+import os
 from setuptools import setup
 from jupyter_packaging.setupbase import (
     create_cmdclass, find_packages, __version__
 )
 
 
+here = os.path.dirname(__file__)
+
+
 setup_args = dict(
     name            = 'jupyter-packaging',
     version         = __version__,
-    packages        = find_packages('.'),
+    packages        = find_packages(here),
     description     = "Jupyter Packaging Utilities",
     long_description= """
     This package contains utilities for making Python packages with

--- a/tests/test_find_packages.py
+++ b/tests/test_find_packages.py
@@ -11,3 +11,18 @@ root = os.path.join(here, os.pardir)
 def test_finds_itself():
     assert ['jupyter_packaging'] == find_packages(root)
 
+
+def test_finds_subpackages(tmpdir):
+    a = tmpdir.mkdir('packageA')
+    sub_a1 = a.mkdir('sub1')
+    sub_a2 = a.mkdir('sub2')
+    b = tmpdir.mkdir('packageB')
+    sub_b1 = b.mkdir('sub1')
+    sub_b2 = b.mkdir('sub2')
+    for d in (a, sub_a1, sub_a2, b, sub_b1, sub_b2):
+        d.join('__init__.py').write('')
+
+    expected = ['packageA', 'packageA.sub1', 'packageA.sub2',
+                'packageB', 'packageB.sub1', 'packageB.sub2']
+    assert expected == find_packages(str(tmpdir))
+

--- a/tests/test_find_packages.py
+++ b/tests/test_find_packages.py
@@ -26,3 +26,14 @@ def test_finds_subpackages(tmpdir):
                 'packageB', 'packageB.sub1', 'packageB.sub2']
     assert expected == find_packages(str(tmpdir))
 
+
+def test_finds_only_direct_subpackages(tmpdir):
+    a = tmpdir.mkdir('packageA')
+    sub_a1 = a.mkdir('sub1')
+    sub_a2 = a.mkdir('sub2')
+    # No __init__.py in packageA:
+    for d in (sub_a1, sub_a2):
+        d.join('__init__.py').write('')
+
+    expected = []
+    assert expected == find_packages(str(tmpdir))

--- a/tests/test_find_packages.py
+++ b/tests/test_find_packages.py
@@ -1,0 +1,13 @@
+
+import os
+
+from jupyter_packaging.setupbase import find_packages
+
+
+here = os.path.dirname(__file__)
+root = os.path.join(here, os.pardir)
+
+
+def test_finds_itself():
+    assert ['jupyter_packaging'] == find_packages(root)
+


### PR DESCRIPTION
Is there a reason why we roll our own `find_packages` instead of relying on setuptools'?