### PR TITLE
Ensure targets

### DIFF
--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -4,11 +4,18 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+"""
+This file originates from the 'jupyter-packaging' package, and
+contains a set of useful utilities for including npm packages
+within a Python package.
+"""
+
 import os
 from os.path import join as pjoin
 import functools
 import pipes
 import sys
+from subprocess import check_call
 
 from setuptools import Command
 from setuptools.command.build_py import build_py
@@ -16,7 +23,6 @@ from setuptools.command.sdist import sdist
 from setuptools.command.develop import develop
 from setuptools.command.bdist_egg import bdist_egg
 from distutils import log
-from subprocess import check_call
 
 try:
     from wheel.bdist_wheel import bdist_wheel
@@ -63,7 +69,7 @@ def get_data_files(top):
     data_files = []
     ntrim = len(here + os.path.sep)
 
-    for (d, dirs, filenames) in os.walk(top):
+    for (d, _, filenames) in os.walk(top):
         data_files.append((
             d[ntrim:],
             [pjoin(d, f) for f in filenames]

--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -225,6 +225,8 @@ def mtime(path):
 def install_npm(path=None, build_dir=None, source_dir=None, build_cmd='build', force=False):
     """Return a Command for managing an npm installation.
 
+    Note: The command is skipped if the `--skip-npm` flag is used.
+
     Parameters
     ----------
     path: str, optional
@@ -264,6 +266,26 @@ def install_npm(path=None, build_dir=None, source_dir=None, build_cmd='build', f
                 run(['npm', 'run', build_cmd], cwd=node_package)
 
     return NPM
+
+
+def ensure_targets(targets):
+    """Return a Command that checks that certain files exist.
+
+    Raises a ValueError if any of the files are missing.
+
+    Note: The check is skipped if the `--skip-npm` flag is used.
+    """
+
+    class TargetsCheck(BaseCommand):
+        def run(self):
+            if skip_npm:
+                log.info('Skipping target checks')
+                return
+            missing = [t for t in targets if not os.path.exists(t)]
+            if missing:
+                raise ValueError(('missing files: %s' % missing))
+
+    return TargetsCheck
 
 
 # `shutils.which` function copied verbatim from the Python-3.3 source.

--- a/tests/test_ensure_targets.py
+++ b/tests/test_ensure_targets.py
@@ -1,0 +1,20 @@
+
+import pytest
+
+from jupyter_packaging.setupbase import ensure_targets
+from utils import run_command
+
+
+def test_ensure_existing_targets(destination_dir):
+    local_targets = ['file1.rtf', 'sub/subfile1.rtf']
+    targets = [str(destination_dir.join(t)) for t in local_targets]
+    cmd = ensure_targets(targets)
+    run_command(cmd)
+
+
+def test_ensure_missing_targets(source_dir):
+    local_targets = ['file1.rtf', 'sub/subfile1.rtf']
+    targets = [str(source_dir.join(t)) for t in local_targets]
+    cmd = ensure_targets(targets)
+    with pytest.raises(ValueError):
+        run_command(cmd)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,18 @@
+
+from setuptools.dist import Distribution
+
+
+def mock_dist():
+    return Distribution(dict(
+        script_name='setup.py',
+        packages=['foo'],
+        name='foo',
+    ))
+
+def run_command(cmd):
+    """Run a distutils/setuptools Command """
+    dist = mock_dist()
+    instance = cmd(dist)
+    instance.initialize_options()
+    instance.finalize_options()
+    return instance.run()


### PR DESCRIPTION
Adds a function `ensure_targets` which returns a Command that checks that certain files exist. Useful usage pattern:

```python
combine_commands(
    npm_install(node_root),
    ensure_targets(expected_build_outputs),
)
```

Similar functionality has been around in many instances of jupyter npm commands as a sort of sanity check, so it should be useful to make it available like this.