### PR TITLE
Append data files instead of overwrite them

### DIFF
--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -376,12 +376,13 @@ def wrap_command(cmds, data_dirs, cls, strict=True):
                         pass
 
             result = cls.run(self)
-            data_files = []
-            for dname in data_dirs:
-                data_files.extend(get_data_files(dname))
-            # update data-files in case this created new files
-            self.distribution.data_files = data_files
-            # also update package data
+            if data_dirs:
+                data_files = self.distribution.data_files if self.distribution.data_files else []
+                for dname in data_dirs:
+                    data_files.extend(get_data_files(dname))
+                # update data-files in case this created new files
+                self.distribution.data_files = data_files
+            # update package data
             update_package_data(self.distribution)
             return result
     return WrappedCommand


### PR DESCRIPTION
This allows the data_files argument in setup.py to still work.