### PR TITLE
Fixed a broken test in test_find_packages

### DIFF
--- a/tests/test_find_packages.py
+++ b/tests/test_find_packages.py
@@ -21,10 +21,13 @@ def test_finds_subpackages(tmpdir):
     sub_b2 = b.mkdir('sub2')
     for d in (a, sub_a1, sub_a2, b, sub_b1, sub_b2):
         d.join('__init__.py').write('')
-
-    expected = ['packageA', 'packageA.sub1', 'packageA.sub2',
-                'packageB', 'packageB.sub1', 'packageB.sub2']
-    assert expected == find_packages(str(tmpdir))
+    # using sets ensure order won't matter
+    expected = set([
+        'packageA', 'packageA.sub1', 'packageA.sub2',
+        'packageB', 'packageB.sub1', 'packageB.sub2'
+    ])
+    found = set(find_packages(str(tmpdir)))
+    assert expected == found
 
 
 def test_finds_only_direct_subpackages(tmpdir):


### PR DESCRIPTION
This test was failing when I ran it.

The test checks whether or not packages are found with `find_packages`, but the test was written such that the order the files are read from the file system matters. Both Python 2.7 and 3.x make no guarantees about the order the files are read.

Using a `set` addresses this.