### PR TITLE
Data spec path issues

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,28 @@
+# Do not build feature branch with open Pull Requests
+skip_branch_with_pr: true
+
+# environment variables
+environment:
+  matrix:
+    - PYTHON: "C:\\Miniconda36-x64"
+      PYTHON_VERSION: "3.6.x"
+      PYTHON_MAJOR: 3
+      PYTHON_ARCH: "64"
+
+# scripts that run after cloning repository
+install:
+  # Ensure python scripts are from right version:
+  - 'SET "PATH=%PYTHON%\Scripts;%PYTHON%;%PATH%"'
+  # Update install tools:
+  - 'python -m pip install --upgrade pip'
+  # Install our package:
+  - 'pip install .'
+
+build: off
+
+# to run your custom scripts instead of automatic tests
+test_script:
+  - 'python setup.py --version'
+  - 'python setup.py build_py'
+  - 'python setup.py sdist'
+  - 'python -m pytest'

--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -499,13 +499,13 @@ def _get_file_handler(package_data_spec, data_files_spec):
     return FileHandler
 
 
-def _get_data_files(data_specs, existing):
+def _get_data_files(data_specs, existing, top=HERE):
     """Expand data file specs into valid data files metadata.
 
     Parameters
     ----------
     data_specs: list of tuples
-        See [createcmdclass] for description.
+        See [create_cmdclass] for description.
     existing: list of tuples
         The existing distrubution data_files metadata.
 
@@ -524,7 +524,7 @@ def _get_data_files(data_specs, existing):
         dname = dname.replace(os.sep, '/')
         offset = len(dname) + 1
 
-        files = _get_files(pjoin(dname, pattern))
+        files = _get_files(pjoin(dname, pattern), top=top)
         for fname in files:
             # Normalize the path.
             root = os.path.dirname(fname)

--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -499,6 +499,13 @@ def _get_file_handler(package_data_spec, data_files_spec):
     return FileHandler
 
 
+def _glob_pjoin(*parts):
+    """Join paths for glob processing"""
+    if parts[0] in ('.', ''):
+        parts = parts[1:]
+    return pjoin(*parts).replace(os.sep, '/')
+
+
 def _get_data_files(data_specs, existing, top=HERE):
     """Expand data file specs into valid data files metadata.
 
@@ -521,14 +528,16 @@ def _get_data_files(data_specs, existing, top=HERE):
     # Extract the files and assign them to the proper data
     # files path.
     for (path, dname, pattern) in data_specs or []:
+        if os.path.isabs(dname):
+            dname = os.path.relpath(dname, top)
         dname = dname.replace(os.sep, '/')
-        offset = len(dname) + 1
-
-        files = _get_files(pjoin(dname, pattern), top=top)
+        offset = 0 if dname in ('.', '') else len(dname) + 1
+        files = _get_files(_glob_pjoin(dname, pattern), top=top)
         for fname in files:
             # Normalize the path.
             root = os.path.dirname(fname)
-            full_path = '/'.join([path, root[offset:]])
+            full_path = _glob_pjoin(path, root[offset:])
+            print(dname, root, full_path, offset)
             if full_path.endswith('/'):
                 full_path = full_path[:-1]
             file_data[full_path].append(fname)
@@ -573,7 +582,8 @@ def _get_files(file_patterns, top=HERE):
             dirnames.remove('node_modules')
         for m in matchers:
             for filename in filenames:
-                fn = os.path.relpath(pjoin(root, filename), top)
+                fn = os.path.relpath(_glob_pjoin(root, filename), top)
+                fn = fn.replace(os.sep, '/')
                 if m(fn):
                     files.add(fn.replace(os.sep, '/'))
 
@@ -598,7 +608,7 @@ def _get_package_data(root, file_patterns=None):
     """
     if file_patterns is None:
         file_patterns = ['*']
-    return _get_files(file_patterns, pjoin(HERE, root))
+    return _get_files(file_patterns, _glob_pjoin(HERE, root))
 
 
 def _compile_pattern(pat, ignore_case=True):

--- a/tests/test_datafiles_paths.py
+++ b/tests/test_datafiles_paths.py
@@ -1,0 +1,70 @@
+import os
+
+from jupyter_packaging.setupbase import _get_data_files
+
+
+
+def test_empty_relative_path(tmpdir):
+    tmpdir.mkdir('sub1').join('a.json').write('')
+    tmpdir.mkdir('sub2').join('b.json').write('')
+    spec = [
+        ('my/target', '', '**/*.json')
+    ]
+    res = _get_data_files(spec, None, str(tmpdir))
+    assert sorted(res) == [
+        ('my/target/sub1', ['sub1/a.json']),
+        ('my/target/sub2', ['sub2/b.json']),
+    ]
+
+
+def test_dot_relative_path(tmpdir):
+    tmpdir.mkdir('sub1').join('a.json').write('')
+    tmpdir.mkdir('sub2').join('b.json').write('')
+    spec = [
+        ('my/target', '.', '**/*.json')
+    ]
+    res = _get_data_files(spec, None, str(tmpdir))
+    assert sorted(res) == [
+        ('my/target/sub1', ['sub1/a.json']),
+        ('my/target/sub2', ['sub2/b.json']),
+    ]
+
+
+def test_subdir_relative_path(tmpdir):
+    tmpdir.mkdir('sub1').join('a.json').write('')
+    tmpdir.mkdir('sub2').join('b.json').write('')
+    spec = [
+        ('my/target', 'sub1', '**/*.json')
+    ]
+    res = _get_data_files(spec, None, str(tmpdir))
+    assert sorted(res) == [
+        ('my/target', ['sub1/a.json']),
+    ]
+
+
+
+def test_root_absolute_path(tmpdir):
+    tmpdir.mkdir('sub1').join('a.json').write('')
+    tmpdir.mkdir('sub2').join('b.json').write('')
+    spec = [
+        ('my/target', str(tmpdir), '**/*.json')
+    ]
+    res = _get_data_files(spec, None, str(tmpdir))
+    assert sorted(res) == [
+        ('my/target/sub1', ['sub1/a.json']),
+        ('my/target/sub2', ['sub2/b.json']),
+    ]
+
+
+def test_subdir_absolute_path(tmpdir):
+    tmpdir.mkdir('sub1').join('a.json').write('')
+    tmpdir.mkdir('sub2').join('b.json').write('')
+    spec = [
+        ('my/target', str(tmpdir.join('sub1')), '**/*.json')
+    ]
+    res = _get_data_files(spec, None, str(tmpdir))
+    assert sorted(res) == [
+        ('my/target', ['sub1/a.json']),
+    ]
+
+


### PR DESCRIPTION
- Adds a some tests for `_get_data_files()`, some of which fail.
- Fixes related issues.
- Adds appveyor config. After enabling appveyor for this repo, this should ensure that the tests are also run on Windows platform, which is needed to avoid pathing regressions when using backslash as pathing separator.