### PR TITLE
Additional error checking in run()

### DIFF
--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -214,7 +214,9 @@ def run(cmd, **kwargs):
         cmd = shlex.split(cmd)
     cmd_path = which(cmd[0])
     if not cmd_path:
-        sys.exit("Aborting. Could not find path for cmd: %s" % cmd[0])
+        sys.exit("Aborting. Could not find cmd (%s) in path. "
+                 "If command is not expected to be in user's path, "
+                 "use an absolute path." % cmd[0])
     cmd[0] = cmd_path
     return subprocess.check_call(cmd, **kwargs)
 

--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -212,7 +212,10 @@ def run(cmd, **kwargs):
     kwargs.setdefault('shell', os.name == 'nt')
     if not isinstance(cmd, (list, tuple)) and os.name != 'nt':
         cmd = shlex.split(cmd)
-    cmd[0] = which(cmd[0])
+    cmd_path = which(cmd[0])
+    if not cmd_path:
+        sys.exit("Aborting. Could not find path for cmd: %s" % cmd[0])
+    cmd[0] = cmd_path
     return subprocess.check_call(cmd, **kwargs)
 
 


### PR DESCRIPTION
The BeakerX project ships gradle with the repo and this is not found in the user's path by default, so the call to `which()` returns `None` which is then passed as the first argument to `subprocess.check_call`.

```
>>> from setupbase import run
>>> run("foo")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jmsdnns/Projects/twosigma/bx/jupyter-packaging/jupyter_packaging/setupbase.py", line 219, in run
    return subprocess.check_call(cmd, **kwargs)
  File "/usr/lib/python3.6/subprocess.py", line 286, in check_call
    retcode = call(*popenargs, **kwargs)
  File "/usr/lib/python3.6/subprocess.py", line 267, in call
    with Popen(*popenargs, **kwargs) as p:
  File "/usr/lib/python3.6/subprocess.py", line 709, in __init__
    restore_signals, start_new_session)
  File "/usr/lib/python3.6/subprocess.py", line 1258, in _execute_child
    executable = os.fsencode(executable)
  File "/home/jmsdnns/.virtualenvs/whatevz/lib/python3.6/os.py", line 800, in fsencode
    filename = fspath(filename)  # Does type-checking of `filename`.
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

This PR detects the error and quits instead.

```
>>> from setupbase import run
>>> run("foo")
Aborting. Could not find path for cmd: foo
```

Passing the full path to the command was ultimately the fix for us. Perhaps the error output could be further improved to mention that.