### PR TITLE
which finds python executable

### DIFF
--- a/tests/test_which.py
+++ b/tests/test_which.py
@@ -1,6 +1,7 @@
 
+import sys
 from jupyter_packaging.setupbase import which
 
 
-def test_which_finds_python():
-    assert which('python')
+def test_which_finds_python_executable():
+    assert which(sys.executable)


### PR DESCRIPTION
This test fails on systems where Python 2 is missing. Let us look for the actual python executable.