### PR TITLE
Test using pyproject.toml and modernize

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: python
 python:
-    - 3.5
+    - 3.6
+    - 3.7
     - 3.8
 sudo: false
 env:
 install:
-    - pip install pytest
-    - pip install .
+    - pip install .[test]
 script:
     - python setup.py --version
     - python setup.py build_py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,10 +15,8 @@ install:
   - 'SET "PATH=%PYTHON%\Scripts;%PYTHON%;%PATH%"'
   # Update install tools:
   - 'python -m pip install --upgrade pip'
-  # Install test dpendency
-  - 'pip install pytest'
   # Install our package:
-  - 'pip install .'
+  - 'pip install .[test]'
 
 build: off
 

--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -29,6 +29,8 @@ if os.path.exists('MANIFEST'): os.remove('MANIFEST')
 from setuptools import Command
 from setuptools.command.build_py import build_py
 from setuptools.command.sdist import sdist
+
+# Note: distutils must be imported after setuptools
 from distutils import log
 
 from setuptools.command.develop import develop

--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -79,24 +79,6 @@ def get_version(file, name='__version__'):
     return version_ns[name]
 
 
-def ensure_python(specs):
-    """Given a list of range specifiers for python, ensure compatibility.
-    """
-    if not isinstance(specs, (list, tuple)):
-        specs = [specs]
-    v = sys.version_info
-    part = '%s.%s' % (v.major, v.minor)
-    for spec in specs:
-        if part == spec:
-            return
-        try:
-            if eval(part + spec):
-                return
-        except SyntaxError:
-            pass
-    raise ValueError('Python version %s unsupported' % part)
-
-
 def find_packages(top):
     """
     Find all of the packages.

--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -79,6 +79,29 @@ def get_version(file, name='__version__'):
     return version_ns[name]
 
 
+def ensure_python(specs):
+    """Given a list of range specifiers for python, ensure compatibility.
+    """
+    import warnings
+    warnings.warn(
+        'Deprecated, please use python_requires in the setup function directly',
+        category=DeprecationWarning
+    )
+    if not isinstance(specs, (list, tuple)):
+        specs = [specs]
+    v = sys.version_info
+    part = '%s.%s' % (v.major, v.minor)
+    for spec in specs:
+        if part == spec:
+            return
+        try:
+            if eval(part + spec):
+                return
+        except SyntaxError:
+            pass
+    raise ValueError('Python version %s unsupported' % part)
+
+
 def find_packages(top):
     """
     Find all of the packages.

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,7 @@ from jupyter_packaging.setupbase import (
     create_cmdclass, find_packages, __version__
 )
 
-
 here = os.path.dirname(os.path.abspath(__file__))
-
 
 setup_args = dict(
     name            = 'jupyter-packaging',
@@ -31,6 +29,12 @@ setup_args = dict(
     platforms       = "Linux, Mac OS X, Windows",
     keywords        = ['Jupyter', 'Packaging'],
     cmdclass        = create_cmdclass(),
+    python_requires = '>=3.6',
+    extras_require  = {
+        'test': [
+            'pytest'
+        ],
+    },
     classifiers     = [
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
@@ -38,10 +42,9 @@ setup_args = dict(
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,12 +11,12 @@ def pyproject_toml():
     """A fixture that enables other fixtures to build mock packages
     with that depend on this package.
     """
-    root_path = HERE.joinpath("../..").resolve().replace(os.sep, '/')
+    root_path = HERE.joinpath("../..").resolve()
     return """
 [build-system]
 requires = ["jupyter_packaging@file://%s", "setuptools>=40.8.0", "wheel"]
 build-backend = "setuptools.build_meta"
-""" % root_path
+""" % str(root_path).replace(os.sep, '/')
 
 
 setup = lambda name="jupyter_packaging_test_foo", data_files_spec=None, **kwargs: """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ def pyproject_toml():
     """A fixture that enables other fixtures to build mock packages
     with that depend on this package.
     """
-    root_path = HERE.joinpath("../..").resolve()
+    root_path = HERE.joinpath("../..").resolve().replace(os.sep, '/')
     return """
 [build-system]
 requires = ["jupyter_packaging@file://%s", "setuptools>=40.8.0", "wheel"]


### PR DESCRIPTION
Fixes #43.  Fixes  #24

- Tests using pyproject.toml
- Deprecates `ensure_python` in favor of the builtin `python_requires`
- Sets minimum version to Python 3.6.