### PR TITLE
Import sdist from distutils instead of setuptools

### DIFF
--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -28,9 +28,9 @@ if os.path.exists('MANIFEST'): os.remove('MANIFEST')
 
 from setuptools import Command
 from setuptools.command.build_py import build_py
-from setuptools.command.sdist import sdist
 
 # Note: distutils must be imported after setuptools
+from distutils.command.sdist import sdist
 from distutils import log
 
 from setuptools.command.develop import develop


### PR DESCRIPTION
This fixes some issues we are seeing that stem from differences between distutils and setuptools.