### PR TITLE
Allow --prefix to work

### DIFF
--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -519,7 +519,7 @@ def _get_develop_handler():
             self.finalize_options()
             super(_develop, self).install_for_development()
             self.run_command('handle_files')
-            prefix = self.install_base or self.prefix
+            prefix = self.install_base or self.prefix or sys.prefix
             for target_dir, filepaths in self.distribution.data_files:
                 for filepath in filepaths:
                     filename = os.path.basename(filepath)

--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -521,7 +521,7 @@ def _get_develop_handler():
             for target_dir, filepaths in self.distribution.data_files:
                 for filepath in filepaths:
                     filename = os.path.basename(filepath)
-                    target = os.path.join(sys.prefix, target_dir, filename)
+                    target = os.path.join(self.prefix, target_dir, filename)
                     self.mkpath(os.path.dirname(target))
                     outf, copied = self.copy_file(filepath, target)
 

--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -518,11 +518,10 @@ def _get_develop_handler():
         def install_for_development(self):
             super(_develop, self).install_for_development()
             self.run_command('handle_files')
-            prefix = self.prefix if self.prefix is not None else sys.prefix
             for target_dir, filepaths in self.distribution.data_files:
                 for filepath in filepaths:
                     filename = os.path.basename(filepath)
-                    target = os.path.join(prefix, target_dir, filename)
+                    target = os.path.join(self.install_base, target_dir, filename)
                     self.mkpath(os.path.dirname(target))
                     outf, copied = self.copy_file(filepath, target)
 

--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -518,10 +518,11 @@ def _get_develop_handler():
         def install_for_development(self):
             super(_develop, self).install_for_development()
             self.run_command('handle_files')
+            prefix = self.install_base or sys.prefix
             for target_dir, filepaths in self.distribution.data_files:
                 for filepath in filepaths:
                     filename = os.path.basename(filepath)
-                    target = os.path.join(self.install_base, target_dir, filename)
+                    target = os.path.join(prefix, target_dir, filename)
                     self.mkpath(os.path.dirname(target))
                     outf, copied = self.copy_file(filepath, target)
 

--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -516,9 +516,10 @@ def _get_develop_handler():
     class _develop(develop):
 
         def install_for_development(self):
+            self.finalize_options()
             super(_develop, self).install_for_development()
             self.run_command('handle_files')
-            prefix = self.install_base or sys.prefix
+            prefix = self.install_base or self.prefix
             for target_dir, filepaths in self.distribution.data_files:
                 for filepath in filepaths:
                     filename = os.path.basename(filepath)

--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -518,10 +518,10 @@ def _get_develop_handler():
         def install_for_development(self):
             super(_develop, self).install_for_development()
             self.run_command('handle_files')
+            prefix = self.prefix if self.prefix is not None else sys.prefix
             for target_dir, filepaths in self.distribution.data_files:
                 for filepath in filepaths:
                     filename = os.path.basename(filepath)
-                    prefix = self.prefix if self.prefix is not None else sys.prefix
                     target = os.path.join(prefix, target_dir, filename)
                     self.mkpath(os.path.dirname(target))
                     outf, copied = self.copy_file(filepath, target)

--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -521,7 +521,8 @@ def _get_develop_handler():
             for target_dir, filepaths in self.distribution.data_files:
                 for filepath in filepaths:
                     filename = os.path.basename(filepath)
-                    target = os.path.join(self.prefix, target_dir, filename)
+                    prefix = self.prefix if self.prefix is not None else sys.prefix
+                    target = os.path.join(prefix, target_dir, filename)
                     self.mkpath(os.path.dirname(target))
                     outf, copied = self.copy_file(filepath, target)
 


### PR DESCRIPTION
This PR makes a change from `sys.prefix` to `self.install_base` to allow top-level command to set the --prefix or --install_dir.