### PR TITLE
allow trailing slashes in spec

### DIFF
--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -592,7 +592,7 @@ def _get_data_files(data_specs, existing, *, top=None, exclude=None):
         if os.path.isabs(dname):
             dname = os.path.relpath(dname, top)
 
-        dname = dname.replace(os.sep, '/')
+        dname = dname.replace(os.sep, '/').rstrip('/')
         offset = 0 if dname in ('.', '') else len(dname) + 1
         files = _get_files(_glob_pjoin(dname, pattern), top=top)
 

--- a/tests/test_datafiles_paths.py
+++ b/tests/test_datafiles_paths.py
@@ -65,3 +65,29 @@ def test_subdir_absolute_path(tmpdir):
     ]
 
 
+def test_absolute_trailing_slash(tmpdir):
+    maindir = tmpdir.mkdir('main')
+    maindir.mkdir('sub1').join('a.json').write('')
+    maindir.mkdir('sub2').join('b.json').write('')
+    spec = [
+        ('my/target/', str(tmpdir) + '/', '**/*.*')
+    ]
+    res = _get_data_files(spec, None, top=str(tmpdir))
+    assert sorted(res) == [
+        ('my/target/main/sub1', ['main/sub1/a.json']),
+        ('my/target/main/sub2', ['main/sub2/b.json']),
+    ]
+
+def test_relative_trailing_slash(tmpdir):
+    maindir = tmpdir.mkdir('main')
+    maindir.mkdir('sub1').join('a.json').write('')
+    maindir.mkdir('sub2').join('b.json').write('')
+    spec = [
+        ('my/target/', 'main/', '**/*.json')
+    ]
+    res = _get_data_files(spec, None, top=str(tmpdir))
+    assert sorted(res) == [
+        ('my/target/sub1', ['main/sub1/a.json']),
+        ('my/target/sub2', ['main/sub2/b.json']),
+    ]
+


### PR DESCRIPTION
I had a "tatic" folder in my install, so I figured something was wrong. I remembered trailing slashes being a sensitive topic, and removing that fixed it, but I'd also like to prevent myself from making the same mistake in the future 😄 

I couldn't see any reason why a trailing slash would ever be desired, and no unit tests complained, so assuming this will be strictly better.