### PR TITLE
Fix typo in skip_if_exists

### DIFF
--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -405,7 +405,7 @@ def ensure_targets(targets):
 def skip_if_exists(paths, CommandClass):
     """Skip a command if list of paths exists."""
     def should_skip():
-        return all(Path(path).exist() for path in paths)
+        return all(Path(path).exists() for path in paths)
     class SkipIfExistCommand(Command):
         def initialize_options(self):
             if not should_skip():


### PR DESCRIPTION
Turns out there was a typo in the `should_skip` function revealed by https://github.com/jupyter/jupyter-packaging/pull/58