### PR TITLE
Use sdist from setuptools not distutils

### DIFF
--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -31,9 +31,9 @@ from setuptools import Command
 from setuptools.command.build_py import build_py
 
 # Note: distutils must be imported after setuptools
-from distutils.command.sdist import sdist
 from distutils import log
 
+from setuptools.command.sdist import sdist
 from setuptools.command.develop import develop
 from setuptools.command.bdist_egg import bdist_egg
 


### PR DESCRIPTION
Currently, if using jupyter-packaging in a package with ``pyproject.toml`` and building an sdist with ``python -m build --sdist``, many package files, including ``setup.py`` as well as files defined in ``MANIFEST.in`` don't get included in the source distribution. This is solved by wrapping setuptools' rather than distutils' ``sdist`` command.