### PR TITLE
Fix invalid command build

### DIFF
--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -107,6 +107,7 @@ def wrap_installers(pre_develop=None, pre_dist=None, post_develop=None, post_dis
                 func()
 
         _Wrapped.__name__ = name
+        func.__name__ = name
         cmdclass[name] = _Wrapped
 
     for name in ['pre_develop', 'post_develop', 'pre_dist', 'post_dist']:


### PR DESCRIPTION
Hi everyone! 

I had a problem here when I tried to install my package locally (using jupyter-package):

```sh 
$ python setup.py develop
running develop
running builder
error: invalid command 'builder'
``` 

To fix that (locally) I used:

```python 
try:
    from jupyter_packaging import wrap_installers, npm_builder
    builder = npm_builder(build_cmd="build:prod")
    builder.__name__ = "pre_develop"
    cmdclass = wrap_installers(pre_develop=builder)
except ImportError:
    cmdclass = {}

if __name__ == '__main__':
    setuptools.setup(cmdclass=cmdclass)
```

Not sure if it is something wrong just for me. This PR fixes this problem, forcing the correct name of the function.