### PR TITLE
Add version info helper function

### DIFF
--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -32,7 +32,7 @@ except ImportError:
 # update it when the contents of directories change.
 if os.path.exists('MANIFEST'): os.remove('MANIFEST')
 
-
+from pkg_resources import parse_version
 from setuptools import Command
 from setuptools.command.build_py import build_py
 from setuptools.config import StaticModule
@@ -233,6 +233,15 @@ def get_version(fpath, name='__version__'):
     with io.open(path, encoding="utf8") as f:
         exec(f.read(), {}, version_ns)
     return version_ns[name]
+
+
+def get_version_info(version_str):
+    """Get a version info tuple given a version string"""
+    parsed = parse_version(version_str)
+    version_info = [parsed.major, parsed.minor, parsed.micro]
+    if parsed.base_version != parsed.public:
+        version_info.append(parsed.public[len(parsed.base_version):])
+    return tuple(version_info)
 
 
 def run(cmd, **kwargs):

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ python_requires = >=3.6
 install_requires =
     packaging
     tomlkit
-    setuptools>=46.4.0
+    setuptools>=49.4.0
     wheel
     deprecation
 

--- a/tests/test_utility_functions.py
+++ b/tests/test_utility_functions.py
@@ -13,6 +13,14 @@ def test_get_version():
     assert version == pkg.__version__
 
 
+def test_get_version_info():
+    assert pkg.get_version_info('1.3.0') == (1,3,0)
+    assert pkg.get_version_info('1.3.0a1') == (1,3,0,'a1')
+    assert pkg.get_version_info('1.3.0.dev0') == (1,3,0,'.dev0')
+    with pytest.raises(AttributeError):
+        pkg.get_version_info('1.3.0foo1')
+
+
 def test_combine_commands():
     class MockCommand(pkg.BaseCommand):
         called = 0


### PR DESCRIPTION
Adds a `get_version_info` helper function to get the `version_info` tuple commonly used in Jupyter packages given a version string.