### PR TITLE
Deprecate `get_version_info` and recommend against runtime dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Tools to help build and install Jupyter Python packages that require a pre-build
 ## Usage
 
 There are three ways to use `jupyter-packaging` in another package.
+In general, you should not depend on `jupyter_packaging` as a runtime dependency, only as a build dependency.
 
 ### As a Build Requirement
 
@@ -17,7 +18,7 @@ An example:
 
 ```toml
 [build-system]
-requires = ["jupyter_packaging~=0.9.0,<2"]
+requires = ["jupyter_packaging~=0.10.0,<2"]
 build-backend = "setuptools.build_meta"
 ```
 
@@ -46,7 +47,7 @@ The pre-build command is specified as metadata in `pyproject.toml`:
 
 ```toml
 [build-system]
-requires = ["jupyter_packaging~=0.8.0"]
+requires = ["jupyter_packaging~=0.10.0,<2"]
 build-backend = "jupyter_packaging.build_api"
 
 [tool.jupyter-packaging.builder]
@@ -108,7 +109,6 @@ setup(cmdclass=cmdclass)
 - Tools like [`check-manifest`](https://github.com/mgedmin/check-manifest) or [`manifix`](https://github.com/vidartf/manifix) can be used to ensure the desired assets are included.
 - Simple uses of `data_files` can be handled in `setup.cfg` or in `setup.py`.  If recursive directories are needed use `get_data_files()` from this package.
 - Unfortunately `data_files` are not supported in `develop` mode (a limitation of `setuptools`).  You can work around it by doing a full install (`pip install .`) before the develop install (`pip install -e .`), or by adding a script to push the data files to `sys.base_prefix`.
-
 
 ## Development Install
 

--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -252,18 +252,6 @@ def get_version(fpath, name='__version__'):
     return version_ns[name]
 
 
-def get_version_info(version_str):
-    """Get a version info tuple given a version string"""
-    match = VERSION_REGEX.match(version_str)
-    if not match:
-        raise ValueError(f'Invalid version "{version_str}"')
-    release = match['release']
-    version_info = [int(p) for p in release.split('.')]
-    if release != version_str:
-        version_info.append(version_str[len(release):])
-    return tuple(version_info)
-
-
 def run(cmd, **kwargs):
     """Echo a command before running it."""
     log.info('> ' + list2cmdline(cmd))
@@ -418,6 +406,38 @@ def ensure_targets(targets):
 # ---------------------------------------------------------------------------
 # Deprecated Functions
 # ---------------------------------------------------------------------------
+
+@deprecated(deprecated_in="0.11", removed_in="2.0", current_version=__version__,
+            details="Parse the version info as described in `get_version_info` docstring")
+def get_version_info(version_str):
+    """DEPRECATED: Get a version info tuple given a version string
+
+    Use something like the following instead:
+
+    ```
+    import re
+
+    # Version string must appear intact for tbump versioning
+    __version__ = '1.4.0.dev0'
+
+    # Build up version_info tuple for backwards compatibility
+    pattern = r'(?P<major>\d+).(?P<minor>\d+).(?P<patch>\d+)(?P<rest>.*)'
+    match = re.match(pattern, __version__)
+    parts = [int(match[part]) for part in ['major', 'minor', 'patch']]
+    if match['rest']:
+    parts.append(match['rest'])
+    version_info = tuple(parts)
+    ```
+    """
+    match = VERSION_REGEX.match(version_str)
+    if not match:
+        raise ValueError(f'Invalid version "{version_str}"')
+    release = match['release']
+    version_info = [int(p) for p in release.split('.')]
+    if release != version_str:
+        version_info.append(version_str[len(release):])
+    return tuple(version_info)
+
 
 @deprecated(deprecated_in="0.8", removed_in="1.0", current_version=__version__,
             details="Use `BaseCommand` directly instead")

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -126,3 +126,11 @@ def test__wrap_command():
     cmd(dist).run()
     assert called == True
 
+
+@fail_if_not_removed
+def test_get_version_info():
+    assert pkg.get_version_info('1.3.0') == (1,3,0)
+    assert pkg.get_version_info('1.3.0a1') == (1,3,0,'a1')
+    assert pkg.get_version_info('1.3.0.dev0') == (1,3,0,'.dev0')
+    with pytest.raises(ValueError):
+        pkg.get_version_info('1.3.0foo1')

--- a/tests/test_utility_functions.py
+++ b/tests/test_utility_functions.py
@@ -13,14 +13,6 @@ def test_get_version():
     assert version == pkg.__version__
 
 
-def test_get_version_info():
-    assert pkg.get_version_info('1.3.0') == (1,3,0)
-    assert pkg.get_version_info('1.3.0a1') == (1,3,0,'a1')
-    assert pkg.get_version_info('1.3.0.dev0') == (1,3,0,'.dev0')
-    with pytest.raises(ValueError):
-        pkg.get_version_info('1.3.0foo1')
-
-
 def test_combine_commands():
     class MockCommand(pkg.BaseCommand):
         called = 0


### PR DESCRIPTION
- Recommend against using `jupyter_packaging` as a runtime dependency
- Deprecate `get_version_info` in favor of an inline parser with no dependencies
