### PR TITLE
Fix Handling of npm Parameter

### DIFF
--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -188,6 +188,8 @@ def npm_builder(path=None, build_dir=None, source_dir=None, build_cmd='build',
                 npm_cmd = ['yarn']
             else:
                 npm_cmd = ['npm']
+        elif isinstance(npm, str):
+            npm_cmd = [npm]
 
         if not which(npm_cmd[0]):
             log.error("`{0}` unavailable.  If you're running this command "


### PR DESCRIPTION
The docstring for `npm_builder` said that `npm` could be a string, but it was treated as a list.