### PR TITLE
Fix handling of module metadata in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,7 @@ long_description_content_type="text/markdown",
 [options]
 zip_safe = False
 include_package_data = True
-packages = find:
+py_modules = foo
 python_requires = >=3.6
 """.format(name=name)
 


### PR DESCRIPTION
Fix usage of setuptools metadata in tests to address recent failures seen in [CI](https://github.com/jupyter/jupyter-packaging/actions/runs/953416978). The new version of [build](https://github.com/pypa/build/releases/tag/0.5.0) package is less permissive than the previous in handling module metadata.