### PR TITLE
Disallow deprecated function return incorrect results for Python 3.10

### DIFF
--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -459,6 +459,8 @@ def command_for_func(func):
 def ensure_python(specs):
     """Given a list of range specifiers for python, ensure compatibility.
     """
+    if sys.version_info >= (3, 10):
+        raise RuntimeError("ensure_python is deprecated and not compatible with Python 3.10+")
     if not isinstance(specs, (list, tuple)):
         specs = [specs]
     v = sys.version_info

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -1,5 +1,6 @@
 
 import os
+import sys
 from unittest.mock import patch
 
 from deprecation import fail_if_not_removed
@@ -52,12 +53,19 @@ def test_finds_only_direct_subpackages(tmpdir):
         assert expected == pkg.find_packages(str(tmpdir))
 
 
+@pytest.mark.skipif(sys.version_info >= (3, 10), reason="Not compatible with Python 3.10+")
 def test_ensure_python():
     pkg.ensure_python('>=3.6')
     pkg.ensure_python(['>=3.6', '>=3.5'])
 
     with pytest.raises(ValueError):
         pkg.ensure_python('<3.5')
+
+
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="Tests RuntimeError for Python 3.10+")
+def test_ensure_python_310():
+    with pytest.raises(RuntimeError):
+        pkg.ensure_python('>=3.6')
 
 
 def test_create_cmdclass(make_package_deprecated, mocker):


### PR DESCRIPTION
Fixes: https://github.com/jupyter/jupyter-packaging/issues/93