### PR TITLE
Handle missing yarn

### DIFF
--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -178,7 +178,11 @@ def npm_builder(path=None, build_dir=None, source_dir=None, build_cmd='build',
 
         node_package = path or os.path.abspath(os.getcwd())
         node_modules = pjoin(node_package, 'node_modules')
+
         is_yarn = os.path.exists(pjoin(node_package, 'yarn.lock'))
+        if is_yarn and not which('yarn'):
+            log.warn('yarn not found, ignoring yarn.lock file')
+            is_yarn = False
 
         npm_cmd = npm
 

--- a/tests/test_core_functions.py
+++ b/tests/test_core_functions.py
@@ -58,6 +58,19 @@ def test_npm_builder_yarn(tmp_path, mocker):
     ])
 
 
+def test_npm_builder_missing_yarn(tmp_path, mocker):
+    which = mocker.patch('jupyter_packaging.setupbase.which')
+    run = mocker.patch('jupyter_packaging.setupbase.run')
+    tmp_path.joinpath('yarn.lock').write_text('hello')
+    builder = npm_builder(path=tmp_path)
+    which.side_effect = ['', 'foo']
+    builder()
+    run.assert_has_calls([
+        call(['npm', 'install'], cwd=tmp_path),
+        call(['npm', 'run', 'build'], cwd=tmp_path)
+    ])
+
+
 def test_npm_builder_not_stale(tmp_path, mocker):
     which = mocker.patch('jupyter_packaging.setupbase.which')
     run = mocker.patch('jupyter_packaging.setupbase.run')


### PR DESCRIPTION
Fix handling of `yarn.lock` file when `yarn` is not available.