### PR TITLE
The import of bdist_wheel is optional, must check for None before using it

### DIFF
--- a/jupyter_packaging/setupbase.py
+++ b/jupyter_packaging/setupbase.py
@@ -142,7 +142,8 @@ def wrap_installers(pre_develop=None, pre_dist=None, post_develop=None, post_dis
 
     if pre_dist or post_dist or ensured_targets:
         _make_wrapper(sdist, pre_dist, post_dist)
-        _make_wrapper(bdist_wheel, pre_dist, post_dist)
+        if bdist_wheel:
+            _make_wrapper(bdist_wheel, pre_dist, post_dist)
 
     return cmdclass
 


### PR DESCRIPTION
This PR is forwarded from ipython/ipyparallel#586.

The import of bdist_wheel is optional:
https://github.com/jupyter/jupyter-packaging/blob/b0304d0c07e06f6f7933300e6c841ac006b89e91/jupyter_packaging/setupbase.py#L46-L49

Just like the use of it is None protected here:
https://github.com/jupyter/jupyter-packaging/blob/b0304d0c07e06f6f7933300e6c841ac006b89e91/jupyter_packaging/setupbase.py#L579-L580

The use here must be None protected too:
https://github.com/jupyter/jupyter-packaging/blob/b0304d0c07e06f6f7933300e6c841ac006b89e91/jupyter_packaging/setupbase.py#L145
