### PR TITLE
do not install tests as a top-level package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,5 +39,9 @@ install_requires =
 [options.extras_require]
 test = build; coverage; pre-commit; pytest; pytest-cov; pytest-mock
 
+[options.packages.find]
+exclude =
+    tests
+
 [bdist_wheel]
 universal=1


### PR DESCRIPTION
Explicitly exclude tests from being found by find_packages().
Otherwise, they are installed as top-level site-packages/tests.