### PR TITLE
Remove codecov usage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,6 @@ jobs:
       uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
     - name: Install dependencies
       run: |
-        python -m pip install -U codecov
         pip install -e ".[test]"
     - name: Run the tests
       if: ${{ !startsWith(matrix.python-version, 'pypy') && !startsWith(matrix.os, 'windows') }}
@@ -41,9 +40,6 @@ jobs:
       if: ${{ startsWith(matrix.python-version, 'pypy') || startsWith(matrix.os, 'windows') }}
       run: |
         python -m pytest -vv || python -m pytest -vv --lf
-    - name: Coverage
-      run: |
-        codecov
 
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The package was deleted from PyPI.  We're still enforcing coverage in the build.